### PR TITLE
Warn the user when the number of calibration experiments is low.  -MW

### DIFF
--- a/common/@PulseCalibration/PulseCalibration.m
+++ b/common/@PulseCalibration/PulseCalibration.m
@@ -154,6 +154,11 @@ classdef PulseCalibration < handle
                 end
             end
             
+            % check number of round robins/waveforms and warn user if too low
+            if obj.numShots < 500 % the number 500 is arbitrary
+                warning('Number of experiments is low.  Error estimate could be inaccurate!');
+            end
+    
             % turn on variances
             obj.experiment.saveVariances = true;
             


### PR DESCRIPTION
Seems like a good idea when running and recalibrating GST experiments.