### PR TITLE
optimizer_mixer: Added lookup of logical channel frequency for SSBFreq

### DIFF
--- a/experiments/muWaveDetection/optimize_mixers.m
+++ b/experiments/muWaveDetection/optimize_mixers.m
@@ -1,9 +1,9 @@
-function optimize_mixers(channel, varargin)
+function optimize_mixers(channel, overrideSSBFreq,  varargin)
     %optional input: 1 for prompt window
     assert(~isempty(channel), 'Oops! You must specify a channel to optimize.')
     % create a mixer optimizer object
     cfgFile = fullfile(getpref('qlab', 'cfgDir'), 'optimize_mixer.json');
     optimizer = MixerOptimizer();
-    optimizer.Init(cfgFile, channel, nargin>1 && varargin{1}==1);
+    optimizer.Init(cfgFile, channel, nargin>2 && varargin{1}==1, overrideSSBFreq);
     optimizer.Do();
 end

--- a/experiments/muWaveDetection/src/@MixerOptimizer/MixerOptimizer.m
+++ b/experiments/muWaveDetection/src/@MixerOptimizer/MixerOptimizer.m
@@ -44,7 +44,7 @@ classdef MixerOptimizer < handle
         end
         
         %% class methods
-        function Init(obj, cfgFile, chan, prompt)
+        function Init(obj, cfgFile, chan, prompt, overrideSSBFreq)
             
             % pull in channel parameters from requested logical channel in the Qubit2ChannelMap
             %Quiet down warnings from '-''s in fieldnames
@@ -62,8 +62,10 @@ classdef MixerOptimizer < handle
             
             % ignore SSBFreq value in cfgFile 
             % override with frequency lookup from logical channel
-            obj.expParams.SSBFreq = MixerOptimizer.lookup_logical_channel_frequency(obj.channelParams, ...
-              obj.expParams.SSBFreq);
+            if overrideSSBFreq
+              obj.expParams.SSBFreq = MixerOptimizer.lookup_logical_channel_frequency(obj.channelParams, ...
+                obj.expParams.SSBFreq);
+            end
             
             %Get references to the AWG, uW source, and spectrum analyzer
             tmpStr = regexp(obj.channelParams.physChan, '-', 'split'); % split on '-'


### PR DESCRIPTION
Added a function to lookup the frequency to be used for mixer calibration based on the contents of the LogicalChannel. This will prevent the manual editing of the optimize_mixer.json file when switching logical channels.

Needs to be tested on a experiment machine before merge. PR open for comments.
