### PR TITLE
Feature fixed windows

### DIFF
--- a/analysis/cQED_dataAnalysis/analyzeCalCR.m
+++ b/analysis/cQED_dataAnalysis/analyzeCalCR.m
@@ -1,4 +1,4 @@
-function optvalue = analyzeCalCR(caltype, CRdata,channel, CRname, varargin)
+function optvalue = analyzeCalCR(caltype, CRdata,channel, CRname)
 %simple fit function to get optimum length/phase in a CR calibration
 %and set in pulse params
 
@@ -7,6 +7,11 @@ function optvalue = analyzeCalCR(caltype, CRdata,channel, CRname, varargin)
 % 2 - phase
 
 %channel: channel with the target data
+
+persistent figHandles
+if isempty(figHandles)
+    figHandles = struct();
+end
 
 CRpulsename = CRname;
 
@@ -42,6 +47,7 @@ if(caltype==1)
     fprintf('Length index for CNOT = %f\n', mean([indmin0, indmin1])); 
     fprintf('Optimum length = %f ns\n', optlen)
     fprintf('Mismatch between |0> and |1> = %f ns\n', abs(xpoints(indmin1)-xpoints(indmin0)))
+    CRfigname = 'CRlength';
 elseif(caltype==2)
     %find max contrast
     ctrfit = yfit0-yfit1;
@@ -50,15 +56,16 @@ elseif(caltype==2)
     fprintf('Phase index for maximum contrast = %d\n', indmax)
     fprintf('Optimum phase = %f\n', optphase)
     fprintf('Contrast = %f\n', maxctr/2);
+    CRfigname = 'CRphase';
 else
     frpintf('Calibration type not supported')
     return
 end
 
-if nargin>4
-    figure(varargin{1});  
+if ~isfield(figHandles, CRfigname) || ~ishandle(figHandles.(CRfigname))
+    figHandles.(CRfigname) = figure('Name', CRfigname);
 else
-    figure(101)
+    figure(figHandles.(CRfigname)); clf;
 end
 plot(xpoints, data0, 'b.', xpoints, data1, 'r.', xpoints, yfit0, 'b-', xpoints, yfit1, 'r-','MarkerSize',16);
 legend('ctrlQ in |0>','ctrlQ in |1>');

--- a/analysis/cQED_dataAnalysis/analyzeProcessTomo.m
+++ b/analysis/cQED_dataAnalysis/analyzeProcessTomo.m
@@ -1,7 +1,21 @@
-function [gateFidelity, choiSDP, choiLSQ] = analyzeProcessTomo(data, idealProcess, nbrQubits, nbrPrepPulses, nbrReadoutPulses, nbrCalRepeats)
+function [gateFidelity, choiSDP, choiLSQ] = analyzeProcessTomo(data, idealProcess, nbrQubits, nbrPrepPulses, nbrReadoutPulses, nbrCalRepeats, varargin)
 %analyzeProcess Performs SDP tomography, calculates gates fidelites and plots pauli maps.
 %
 % [gateFidelity, choiSDP] = analyzeProcessTomo(data, idealProcessStr, nbrQubits, nbrPrepPulses, nbrReadoutPulses, nbrRepeats) 
+
+% optional argument: newplot. If true, make new figure windows
+% (default = false)
+
+persistent figHandles
+if isempty(figHandles)
+    figHandles = struct();
+end
+
+if(isempty(varargin))
+    newplot = false;
+else
+    newplot = varargin{1};
+end
 
 %seperate calibration experiments from tomography data and flatten the
 %experiment data
@@ -91,7 +105,15 @@ pauliStrs = pauliStrs(weightIdx);
 cmap = [hot(50); 1-hot(50)];
 cmap = cmap(19:19+63,:); % make a 64-entry colormap
 
-figure()
+if newplot
+    figure();
+else
+    if ~isfield(figHandles, 'pauliMapLSQ') || ~ishandle(figHandles.('pauliMapLSQ'))
+        figHandles.('pauliMapLSQ') = figure('Name', 'pauliMapLSQ');
+    else
+        figure(figHandles.('pauliMapLSQ')); clf;
+    end
+end
 imagesc(real(pauliMapLSQ),[-1,1])
 colormap(cmap)
 colorbar
@@ -105,7 +127,15 @@ xlabel('Input Pauli Operator');
 ylabel('Output Pauli Operator');
 title('LSQ Reconstruction');
 
-figure()
+if newplot
+    figure();
+else
+    if ~isfield(figHandles, 'pauliMapExp') || ~ishandle(figHandles.('pauliMapExp'))
+        figHandles.('pauliMapExp') = figure('Name', 'pauliMapExp');
+    else
+        figure(figHandles.('pauliMapExp')); clf;
+    end
+end
 imagesc(real(pauliMapExp),[-1,1])
 colormap(cmap)
 colorbar
@@ -119,7 +149,15 @@ xlabel('Input Pauli Operator');
 ylabel('Output Pauli Operator');
 title('MLE Reconstruction');
 
-figure()
+if newplot
+    figure();
+else
+    if ~isfield(figHandles, 'pauliMapIdeal') || ~ishandle(figHandles.('pauliMapIdeal'))
+        figHandles.('pauliMapIdeal') = figure('Name', 'pauliMapIdeal');
+    else
+        figure(figHandles.('pauliMapIdeal')); clf;
+    end
+end
 imagesc(real(pauliMapIdeal),[-1,1])
 colormap(cmap)
 colorbar

--- a/analysis/cQED_dataAnalysis/analyzeStateTomo.m
+++ b/analysis/cQED_dataAnalysis/analyzeStateTomo.m
@@ -53,13 +53,13 @@ varMat = diag(varData);
 %First least squares
 rhoLSQ = QST_LSQ(tomoData, varMat, measPulseMap, measOpMap, measPulseUs, measOps, nbrQubits);
 
-pauliSetPlot(rho2pauli(rhoLSQ));
+pauliSetPlot(rho2pauli(rhoLSQ),401);
 title('LSQ Inversion Pauli Decomposition');
 
 %Now constrained SDP
 rhoSDP = QST_SDP_uncorrelated(tomoData, varMat, measPulseMap, measOpMap, measPulseUs, measOps, nbrQubits);
 
-pauliSetPlot(rho2pauli(rhoSDP));
+pauliSetPlot(rho2pauli(rhoSDP),402);
 title('SDP Inversion Pauli Decomposition');
 
 

--- a/analysis/cQED_dataAnalysis/analyzeStateTomo.m
+++ b/analysis/cQED_dataAnalysis/analyzeStateTomo.m
@@ -1,9 +1,17 @@
-function [rhoLSQ, rhoSDP] = analyzeStateTomo(datastruct, nbrQubits, nbrPulses, nbrCalRepeats)
+function [rhoLSQ, rhoSDP] = analyzeStateTomo(datastruct, nbrQubits, nbrPulses, nbrCalRepeats, varargin)
 % analyzeStateTomo Wrapper function for state tomography.
 %
 % [rhoLSQ, rhoSDP, rhoWizard] = analyzeStateTomo(data, nbrQubits, nbrPulses, nbrCalRepeats)
 %
 % Expects tomography data then calibration data
+% optional argument: newplot. If true, make new figure windows
+% (default = false)
+
+if(isempty(varargin))
+    newplot = false;
+else
+    newplot = varargin{1};
+end
 
 %First separate out the data
 data=datastruct.data;
@@ -53,13 +61,21 @@ varMat = diag(varData);
 %First least squares
 rhoLSQ = QST_LSQ(tomoData, varMat, measPulseMap, measOpMap, measPulseUs, measOps, nbrQubits);
 
-pauliSetPlot(rho2pauli(rhoLSQ),401);
+if ~newplot
+    pauliSetPlot(rho2pauli(rhoLSQ),'StateTomo_LSQ');
+else
+    pauliSetPlot(rho2pauli(rhoLSQ));
+end
 title('LSQ Inversion Pauli Decomposition');
 
 %Now constrained SDP
 rhoSDP = QST_SDP_uncorrelated(tomoData, varMat, measPulseMap, measOpMap, measPulseUs, measOps, nbrQubits);
 
-pauliSetPlot(rho2pauli(rhoSDP),402);
+if ~newplot
+    pauliSetPlot(rho2pauli(rhoSDP),'StateTomo_SDP');
+else
+    pauliSetPlot(rho2pauli(rhoSDP));
+end
 title('SDP Inversion Pauli Decomposition');
 
 

--- a/analysis/cQED_dataAnalysis/fitramsey2D.m
+++ b/analysis/cQED_dataAnalysis/fitramsey2D.m
@@ -5,6 +5,11 @@ function [T2s, freqs] = fitramsey2D(xdata, ydata)
 % xdata : vector of time samples
 % ydata : matrix of data (each Ramsey experiment along a row)
 
+persistent figHandles
+if isempty(figHandles)
+    figHandles = struct();
+end
+
 numScans = size(ydata,1);
 T2s = zeros(numScans, 1);
 freqs = zeros(numScans, 1);
@@ -23,7 +28,11 @@ for cnt=1:numScans
     p = [mean(y) abs(amps(biggestC)) Ts(biggestC) 2*pi*freqs(biggestC) 0];
     [beta,r,j] = nlinfit(xdata, y, rabif, p);
 
-    figure(100)
+    if ~isfield(figHandles, 'Ramsey') || ~ishandle(figHandles.('Ramsey'))
+        figHandles.('Ramsey') = figure('Name', 'Ramsey');
+    else
+        figure(figHandles.('Ramsey')); clf;
+    end
     subplot(3,1,2:3)
     plot(xdata,y,'o')
     hold on

--- a/analysis/cQED_dataAnalysis/fitt1.m
+++ b/analysis/cQED_dataAnalysis/fitt1.m
@@ -3,6 +3,12 @@ function [t1, t1error] = fitt1(xdata, ydata)
 % usage: [t1, t1error] = fitt1(data, xstart, xend)
 
 % if no input arguments, try to get the data from the current figure
+
+persistent figHandles
+if isempty(figHandles)
+    figHandles = struct();
+end
+
 if nargin < 2 
     h = gcf;
     line = findall(h, 'Type', 'Line');
@@ -11,7 +17,12 @@ if nargin < 2
     % save figure title
     plotTitle = get(get(gca, 'Title'), 'String');
 else
-    h = figure;
+    if ~isfield(figHandles, 'T1') || ~ishandle(figHandles.('T1'))
+        figHandles.('T1') = figure('Name', 'T1');
+        h = figHandles.('T1');
+    else
+        h = figure(figHandles.('T1')); clf;
+    end
     plotTitle = '';
 end
 xdata = xdata(:);

--- a/analysis/cQED_dataAnalysis/pauliSetPlot.m
+++ b/analysis/cQED_dataAnalysis/pauliSetPlot.m
@@ -1,4 +1,4 @@
-function pauliSetPlot(pauliVec)
+function pauliSetPlot(pauliVec, varargin)
 
 nbrQubits = log2(length(pauliVec))/2;
 [~, pauliStrs] = paulis(nbrQubits);
@@ -9,7 +9,11 @@ weights = cellfun(@pauliHamming, pauliStrs);
 pauliStrs = pauliStrs(weightIdx);
 pauliVec = pauliVec(weightIdx);
 
-figure();
+if nargin>1
+    figure(varargin{1}); clf;
+else 
+    figure();
+end
 bar(pauliVec);
 axis([0.5, length(pauliVec)+0.5,-1.1, 1.1]); 
 set(gca, 'XTick', 1:length(pauliStrs));

--- a/analysis/cQED_dataAnalysis/pauliSetPlot.m
+++ b/analysis/cQED_dataAnalysis/pauliSetPlot.m
@@ -1,5 +1,10 @@
 function pauliSetPlot(pauliVec, varargin)
 
+persistent figHandles
+if isempty(figHandles)
+    figHandles = struct();
+end
+
 nbrQubits = log2(length(pauliVec))/2;
 [~, pauliStrs] = paulis(nbrQubits);
 
@@ -9,9 +14,13 @@ weights = cellfun(@pauliHamming, pauliStrs);
 pauliStrs = pauliStrs(weightIdx);
 pauliVec = pauliVec(weightIdx);
 
-if nargin>1
-    figure(varargin{1}); clf;
-else 
+if ~isempty(varargin)
+    if ~isfield(figHandles, varargin{1}) || ~ishandle(figHandles.(varargin{1}))
+        figHandles.(varargin{1}) = figure('Name', varargin{1});
+    else
+        figure(figHandles.(varargin{1})); clf;
+    end
+else
     figure();
 end
 bar(pauliVec);

--- a/experiments/muWaveDetection/calibrateCR.m
+++ b/experiments/muWaveDetection/calibrateCR.m
@@ -82,4 +82,4 @@ ExpScripter2('CRcal_ph', expSettings, 'lockSegments');
 
 %analyze the sequence and updates CR pulse
 data=load_data('latest');
-optphase = analyzeCalCR(2,data,CalParams.channel,CalParams.CR, 102);
+optphase = analyzeCalCR(2,data,CalParams.channel,CalParams.CR);

--- a/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_ampPhase_bySweep.m
+++ b/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_ampPhase_bySweep.m
@@ -21,7 +21,7 @@ function [ampFactor, phaseSkew] = optimize_mixer_ampPhase_bySweep(obj)
 
 persistent figHandles
 if isempty(figHandles)
-                figHandles = struct();
+    figHandles = struct();
 end
 
 % unpack constants from cfg file

--- a/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_ampPhase_bySweep.m
+++ b/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_ampPhase_bySweep.m
@@ -42,6 +42,7 @@ tmpLine = plot(axesHAmp, ampPts/awgAmp, measPowers1, 'b*');
 hold on
 xlabel('Amplitude Factor');
 ylabel('Peak Power (dBm)');
+title(obj.chan);
 
 axesHPhase = subplot(2,1,2);
 hold on

--- a/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_ampPhase_bySweep.m
+++ b/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_ampPhase_bySweep.m
@@ -19,6 +19,11 @@
 
 function [ampFactor, phaseSkew] = optimize_mixer_ampPhase_bySweep(obj)
 
+persistent figHandles
+if isempty(figHandles)
+                figHandles = struct();
+end
+
 % unpack constants from cfg file
 ExpParams = obj.expParams;
 awgAmp = obj.awgAmp;
@@ -35,7 +40,11 @@ fprintf('\nStarting sweep search for optimal amp/phase\n');
 %First we scan the amplitude with the phase at zero
 ampPts = linspace(ExpParams.Sweep.ampFactor.start*awgAmp, ExpParams.Sweep.ampFactor.stop*awgAmp, ExpParams.Sweep.ampFactor.numPoints);
 
-figure(302); clf;
+if ~isfield(figHandles, 'mixAmpPhase') || ~ishandle(figHandles.('mixAmpPhase'))
+figHandles.('mixAmpPhase') = figure('Name', 'I-Q Amp/Skew'); 
+else
+    figure(figHandles.('mixAmpPhase')); clf;
+end
 axesHAmp = subplot(2,1,1);
 measPowers1 = nan(1, length(ampPts));
 tmpLine = plot(axesHAmp, ampPts/awgAmp, measPowers1, 'b*');

--- a/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_ampPhase_bySweep.m
+++ b/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_ampPhase_bySweep.m
@@ -35,7 +35,7 @@ fprintf('\nStarting sweep search for optimal amp/phase\n');
 %First we scan the amplitude with the phase at zero
 ampPts = linspace(ExpParams.Sweep.ampFactor.start*awgAmp, ExpParams.Sweep.ampFactor.stop*awgAmp, ExpParams.Sweep.ampFactor.numPoints);
 
-figure();
+figure(302); clf;
 axesHAmp = subplot(2,1,1);
 measPowers1 = nan(1, length(ampPts));
 tmpLine = plot(axesHAmp, ampPts/awgAmp, measPowers1, 'b*');

--- a/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_offsets_bySweep.m
+++ b/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_offsets_bySweep.m
@@ -33,7 +33,7 @@ offsetPts = linspace(ExpParams.Sweep.offset.start, ExpParams.Sweep.offset.stop, 
 vertex = struct();
 %Sweep the I with Q at 0
 measPowers1 = nan(1, length(offsetPts));
-figure();
+figure(301); clf;
 axesH = axes();
 tmpLine = plot(axesH,offsetPts, measPowers1, 'b*');
 hold on

--- a/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_offsets_bySweep.m
+++ b/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_offsets_bySweep.m
@@ -39,7 +39,7 @@ tmpLine = plot(axesH,offsetPts, measPowers1, 'b*');
 hold on
 set(get(get(tmpLine,'Annotation'),'LegendInformation'),...
     'IconDisplayStyle','off'); % Exclude line from legend
-xlabel('Offset Voltage (V)');
+xlabel(['Offset Voltage ' obj.chan ' (V)']);
 ylabel('Peak Power (dBm)');
 for ct = 1:length(offsetPts)
     vertex.a = offsetPts(ct); vertex.b = 0;

--- a/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_offsets_bySweep.m
+++ b/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_offsets_bySweep.m
@@ -24,7 +24,7 @@ function [i_offset, q_offset] = optimize_mixer_offsets_bySweep(obj)
 
 persistent figHandles
 if isempty(figHandles)
-                figHandles = struct();
+    figHandles = struct();
 end
 
 % unpack constants from cfg file

--- a/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_offsets_bySweep.m
+++ b/experiments/muWaveDetection/src/@MixerOptimizer/optimize_mixer_offsets_bySweep.m
@@ -22,6 +22,11 @@
 
 function [i_offset, q_offset] = optimize_mixer_offsets_bySweep(obj)
 
+persistent figHandles
+if isempty(figHandles)
+                figHandles = struct();
+end
+
 % unpack constants from cfg file
 ExpParams = obj.expParams;
 awg_I_channel = str2double(obj.channelParams.physChan(end-1));
@@ -33,7 +38,11 @@ offsetPts = linspace(ExpParams.Sweep.offset.start, ExpParams.Sweep.offset.stop, 
 vertex = struct();
 %Sweep the I with Q at 0
 measPowers1 = nan(1, length(offsetPts));
-figure(301); clf;
+if ~isfield(figHandles, 'mixOffset') || ~ishandle(figHandles.('mixOffset'))
+    figHandles.('mixOffset') = figure('Name', 'I-Q offsets'); 
+else
+    figure(figHandles.('mixOffset')); clf;
+end
 axesH = axes();
 tmpLine = plot(axesH,offsetPts, measPowers1, 'b*');
 hold on


### PR DESCRIPTION
Sets standard plots to fixed windows, instead of opening a new window per plot. The assignment of figure numbers is arbitrary, though, and may overwrite other plots. 

Also adds some label identifier to mixer calibration plots. 