### PR TITLE
Do not run APS2 after setting amplitude

### DIFF
--- a/common/+sweeps/AWGChannel.m
+++ b/common/+sweeps/AWGChannel.m
@@ -63,7 +63,6 @@ classdef AWGChannel < sweeps.Sweep
                     case 'APS2'
                         stop(obj.Instr);
                         set_channel_scale(obj.Instr, ch, obj.points(index));
-                        run(obj.Instr);
                     otherwise
                         error('Unrecognized AWG type');
                 end

--- a/common/+sweeps/AWGChannel.m
+++ b/common/+sweeps/AWGChannel.m
@@ -61,7 +61,6 @@ classdef AWGChannel < sweeps.Sweep
                     case {'TekAWG', 'deviceDrivers.APS', 'APS'}
                         obj.Instr.setAmplitude(ch, obj.points(index));
                     case 'APS2'
-                        stop(obj.Instr);
                         set_channel_scale(obj.Instr, ch, obj.points(index));
                     otherwise
                         error('Unrecognized AWG type');


### PR DESCRIPTION
The APS2 should only run after digitizer is ready. This was causing
segments to be shifted at each iteration of a loop sweeping the
amplitude of the APS2 with the digitizer trigger.  I'm not sure it the
stop command is necessary.
--DR