### PR TITLE
Enable saving >1 kernels per channel

### DIFF
--- a/common/+MeasFilters/SingleShot.m
+++ b/common/+MeasFilters/SingleShot.m
@@ -28,6 +28,7 @@ classdef SingleShot < MeasFilters.MeasFilter
         saveKernel = true
         optIntegrationTime = true
         setThreshold = false
+        kernelNumber = NaN
     end
     
     methods
@@ -44,6 +45,9 @@ classdef SingleShot < MeasFilters.MeasFilter
             end
             if isfield(settings, 'setThreshold')
                 obj.setThreshold = settings.setThreshold;
+            end
+            if isfield(settings, 'kernelNumber')
+                obj.kernelNumber = settings.kernelNumber;
             end
         end
         
@@ -149,8 +153,13 @@ classdef SingleShot < MeasFilters.MeasFilter
                     if ~obj.optIntegrationTime
                         intPt = length(kernel);
                     end
-                    dlmwrite(strcat('kernel_',obj.dataSource,'_real.csv'), real(kernel)); 
-                    dlmwrite(strcat('kernel_',obj.dataSource,'_imag.csv'), imag(kernel));
+                    if ~isnan(obj.kernelNumber)
+                        kernelSuffix = [obj.dataSource '_' num2str(obj.kernelNumber)];
+                    else
+                        kernelSuffix = obj.dataSource;
+                    end
+                    dlmwrite(strcat('kernel_',kernelSuffix,'_real.csv'), real(kernel)); 
+                    dlmwrite(strcat('kernel_',kernelSuffix,'_imag.csv'), imag(kernel));
                 end
                 
                 obj.pdfData.maxFidelity_I = 1-0.5*(1-0.5*(bins(2)-bins(1))*sum(abs(gPDF-ePDF)));

--- a/common/@SingleShotFidelity/SingleShotFidelity.m
+++ b/common/@SingleShotFidelity/SingleShotFidelity.m
@@ -67,6 +67,10 @@ classdef SingleShotFidelity < handle
             
             obj.autoSelectAWGs = settings.autoSelectAWGs;
             
+            if ~isfield(settings,'kernelNumber')
+                obj.settings.kernelNumber = NaN;
+            end
+            
             % add instruments
             for instrument = fieldnames(instrSettings)'
                 fprintf('Connecting to %s\n', instrument{1});
@@ -124,7 +128,7 @@ classdef SingleShotFidelity < handle
             add_measurement(obj.experiment, 'SingleShot',...
                 MeasFilters.SingleShot('SingleShot', struct('dataSource', obj.settings.dataSource, 'plotMode', 'real/imag', 'plotScope', true,...
                 'logisticRegression', obj.settings.logisticRegression, 'saveKernel', obj.settings.saveKernel, 'optIntegrationTime', ...
-                obj.settings.optIntegrationTime, 'setThreshold', obj.settings.setThreshold)));
+                obj.settings.optIntegrationTime, 'setThreshold', obj.settings.setThreshold, 'kernelNumber', obj.settings.kernelNumber)));
             curSource = obj.settings.dataSource;
             while (true)
                sourceParams = measSettings.(curSource);


### PR DESCRIPTION
Useful when one physical X6 channel has multiple signals (at different frequencies)
--DR