### PR TITLE
Update DataNamer.m

### DIFF
--- a/common/util/DataNamer.m
+++ b/common/util/DataNamer.m
@@ -31,7 +31,7 @@ classdef DataNamer < handle
                 while (ct > 0)
                     fileList = dir(fullfile(obj.dataDir, obj.deviceName, folderNames{ct}, '*.h5'));
                     % pull out the number from ###_device_experiment.out
-                    tokens = regexp({fileList.name}, '(\d+)_.*\.h5', 'tokens', 'once');
+                    tokens = regexp({fileList.name}, '(\d+).*\.h5', 'tokens', 'once');
                     if ~isempty(tokens)
                         expNums = cellfun(@str2double, tokens);
                         newval = max(expNums);


### PR DESCRIPTION
DataNamer would cause ExpManager to fail if there was a data file without a device name.
This allows for regexp to catch files without a device Name.

i.e., `0.h5` should be caught as `0` instead of `''`.