### PR TITLE
Update freq. after Ramsey cal.

### DIFF
--- a/common/@PulseCalibration/PulseCalibrationDo.m
+++ b/common/@PulseCalibration/PulseCalibrationDo.m
@@ -276,6 +276,9 @@ if settings.DoRamsey
     warning('on', 'json:fieldNameConflict');
     sourceName = channelLib.channelDict.(mangledPhysChan).generator;
     instrLib.instrDict.(sourceName).frequency = qubitSource.frequency;
+    expSettings = json.read(getpref('qlab', 'CurScripterFile'));
+    expSettings.instruments.(sourceName).frequency = qubitSource.frequency;
+    json.write(expSettings, getpref('qlab', 'CurScripterFile'), 'indent', 2);
 end
 
 json.write(instrLib, getpref('qlab', 'InstrumentLibraryFile'), 'indent', 2);


### PR DESCRIPTION
ExpScripter reads 'CurScripterFile'. Not updating it here would force
the user to press Apply to update the values from
'InstrumentLibraryFile'.
--DR