### PR TITLE
Keep track of calibration results

### DIFF
--- a/common/@PulseCalibration/PulseCalibrationDo.m
+++ b/common/@PulseCalibration/PulseCalibrationDo.m
@@ -294,6 +294,26 @@ obj.finished = true;
         
     end
 
+%log
+if settings.dolog
+    expSettings = json.read(getpref('qlab', 'CurScripterFile'));
+    warning('off', 'json:fieldNameConflict');
+    chanSettings = json.read(getpref('qlab', 'ChannelParamsFile'));
+    warning('on', 'json:fieldNameConflict');
+    channelParams = chanSettings.channelDict.(settings.Qubit);
+    mangledPhysChan = genvarname(channelParams.physChan);
+    qubitSource = expSettings.instruments.(chanSettings.channelDict.(mangledPhysChan).generator);
+    freq = qubitSource.frequency;
+    piamp = chanSettings.channelDict.(settings.Qubit).pulseParams.piAmp;
+    pi2amp = chanSettings.channelDict.(settings.Qubit).pulseParams.pi2Amp;
+    amps = [piamp, pi2amp];
+    fid = fopen(fullfile(settings.calpath, ['freqvec_' settings.Qubit '.csv']), 'at');
+    fprintf(fid, '%s\t%.9f\n', datestr(now,31), freq);
+    fclose(fid);
+    fid = fopen(fullfile(settings.calpath, ['ampvec_' settings.Qubit '.csv']), 'at');
+    fprintf(fid, '%s\t%.4f\t%.4f\n', datestr(now,31), amps(1), amps(2));
+    fclose(fid);
+end
 
 end
 

--- a/experiments/muWaveDetection/calibratePulses.m
+++ b/experiments/muWaveDetection/calibratePulses.m
@@ -64,10 +64,10 @@ if dolog
     piamp = chanSettings.channelDict.(qubit).pulseParams.piAmp;
     pi2amp = chanSettings.channelDict.(qubit).pulseParams.pi2Amp;
     amps = [piamp, pi2amp];
-    fid = fopen(fullfile(calpath, 'freqvec_', qubit, '.csv'), 'at');
+    fid = fopen(fullfile(calpath, ['freqvec_' qubit '.csv']), 'at');
     fprintf(fid, '%s\t%.9f\n', datestr(now,31), freq)
     fclose(fid);
-    fid = fopen(fullfile(calpath, 'ampvec_', qubit, '.csv'), 'at');
+    fid = fopen(fullfile(calpath, ['ampvec_' qubit '.csv']), 'at');
     fprintf(fid, '%s\t%.9f\t%.4f\n', datestr(now,31), amps(1), amps(2))
     fclose(fid);
 end

--- a/experiments/muWaveDetection/calibratePulses.m
+++ b/experiments/muWaveDetection/calibratePulses.m
@@ -6,10 +6,6 @@ if ~exist('qubit', 'var')
     qubit = 'q1';
 end
 
-%optional logging of frequency and amplitudes over time
-dolog = true;
-calpath = 'C:\Users\qlab\Documents\data\Cal_Logs';
-
 % construct minimal cfg file
 ExpParams = struct();
 ExpParams.Qubit = qubit;
@@ -36,6 +32,10 @@ ExpParams.dataType = 'real'; %'amp', 'phase', 'real', or 'imag';
 ExpParams.cfgFile = getpref('qlab', 'CurScripterFile');
 ExpParams.SoftwareDevelopmentMode = 0;
 
+%optional logging of frequency and amplitudes over time
+ExpParams.dolog = false;
+ExpParams.calpath = 'C:\Users\qlab\Documents\data\Cal_Logs';
+
 if nargin>1 %updates ExpParams with optional input settings
 %Remove overlapping fields from default ExpParams
 ExpParams = rmfield(ExpParams, intersect(fieldnames(ExpParams), fieldnames(varargin{1})));
@@ -51,24 +51,4 @@ pulseCal = PulseCalibration();
 pulseCal.Init(ExpParams);
 pulseCal.Do();
 
-%log
-if dolog
-    expSettings = json.read(getpref('qlab', 'CurScripterFile'));
-    warning('off', 'json:fieldNameConflict');
-    chanSettings = json.read(getpref('qlab', 'ChannelParamsFile'));
-    warning('on', 'json:fieldNameConflict');
-    channelParams = chanSettings.channelDict.(qubit);
-    mangledPhysChan = genvarname(channelParams.physChan);
-    qubitSource = expSettings.instruments.(chanSettings.channelDict.(mangledPhysChan).generator);
-    freq = qubitSource.frequency;
-    piamp = chanSettings.channelDict.(qubit).pulseParams.piAmp;
-    pi2amp = chanSettings.channelDict.(qubit).pulseParams.pi2Amp;
-    amps = [piamp, pi2amp];
-    fid = fopen(fullfile(calpath, ['freqvec_' qubit '.csv']), 'at');
-    fprintf(fid, '%s\t%.9f\n', datestr(now,31), freq)
-    fclose(fid);
-    fid = fopen(fullfile(calpath, ['ampvec_' qubit '.csv']), 'at');
-    fprintf(fid, '%s\t%.4f\t%.4f\n', datestr(now,31), amps(1), amps(2))
-    fclose(fid);
-end
 end

--- a/experiments/muWaveDetection/calibratePulses.m
+++ b/experiments/muWaveDetection/calibratePulses.m
@@ -68,7 +68,7 @@ if dolog
     fprintf(fid, '%s\t%.9f\n', datestr(now,31), freq)
     fclose(fid);
     fid = fopen(fullfile(calpath, ['ampvec_' qubit '.csv']), 'at');
-    fprintf(fid, '%s\t%.9f\t%.4f\n', datestr(now,31), amps(1), amps(2))
+    fprintf(fid, '%s\t%.4f\t%.4f\n', datestr(now,31), amps(1), amps(2))
     fclose(fid);
 end
 end


### PR DESCRIPTION
Keep a running log of qubit calibrated frequencies and pulse amplitudes. Useful to monitor fluctuations or unsuccessful calibrations
--DR