### PR TITLE
Calibrate CR amp. with phase estimation

### DIFF
--- a/common/@PulseCalibration/PhaseEstimationSequence2q.m
+++ b/common/@PulseCalibration/PhaseEstimationSequence2q.m
@@ -1,0 +1,12 @@
+function [filename, segmentPoints] = PulsePhaseEstimate2q(obj, control, target, numPulses, amplitude)
+
+[thisPath, ~] = fileparts(mfilename('fullpath'));
+scriptName = fullfile(thisPath, 'PhaseEstimationSequence2q.py');
+[status, result] = system(sprintf('python "%s" "%s" %s %s %d %f', scriptName, getpref('qlab', 'PyQLabDir'), control, target, numPulses, amplitude), '-echo');
+
+segmentPoints = -1:0.25:numPulses+0.75;
+
+filename = obj.getAWGFileNames('RepeatCal');
+
+end
+

--- a/common/@PulseCalibration/PhaseEstimationSequence2q.py
+++ b/common/@PulseCalibration/PhaseEstimationSequence2q.py
@@ -1,0 +1,39 @@
+import argparse
+import sys, os
+import numpy as np
+from copy import copy
+parser = argparse.ArgumentParser()
+parser.add_argument('pyqlabpath', help='path to PyQLab directory')
+parser.add_argument('qc', help='control qubit')
+parser.add_argument('qt', help='target qubit')
+parser.add_argument('numPulses', type=int, help='log2(n) of the longest sequence n')
+parser.add_argument('amplitude', type=float, help='pulse amplitude')
+args = parser.parse_args()
+
+from QGL import *
+
+qc = QubitFactory(args.qc)
+qt = QubitFactory(args.qt)
+amp = args.amplitude
+
+CRchan = ChannelLibrary.EdgeFactory(qc, qt)
+CRchan.pulseParams['amp'] = amp
+
+pPulse = ZX90_CR(qc,qt)
+mPulse = X90m(qt)
+
+# Exponentially growing amplications of the target pulse
+# (1, 2, 4, 8, 16, 32, 64, 128, ...) x X90
+# first two sequence give measurement calibration
+seqs = [pPulse*n for n in 2**np.arange(args.numPulses+1)]
+
+# measure each along Z or X/Y
+seqs = [s + m for s in seqs for m in [ [MEAS(qt)], [mPulse, MEAS(qt)] ]]
+
+# tack on calibrations
+seqs = [[Id(qt), MEAS(qt)], [X(qt), MEAS(qt)]] + seqs
+
+# repeat each
+repeated_seqs = [copy(s) for s in seqs for _ in range(2)]
+
+fileNames = compile_to_hardware(repeated_seqs, fileName='RepeatCal/RepeatCal')

--- a/common/@PulseCalibration/measure_rotation_angle.m
+++ b/common/@PulseCalibration/measure_rotation_angle.m
@@ -1,4 +1,4 @@
-function [phase, sigma] = measure_rotation_angle(obj, amp, direction, target)
+function [phase, sigma] = measure_rotation_angle(obj, amp, direction, target, varargin)
     % inputs:
     %   amp - pulse amplitude
     %   direction - 'X' or 'Y'
@@ -25,7 +25,11 @@ function [phase, sigma] = measure_rotation_angle(obj, amp, direction, target)
     
     % create sequence and measure
     if ~obj.testMode
-        [filenames, segmentPoints] = obj.PhaseEstimationSequence(obj.settings.Qubit, direction, numPulses, amp);
+        if isfield(obj.settings, 'CRpulses')
+            [filenames, segmentPoints] = obj.PhaseEstimationSequence2q(obj.settings.Qubit, varargin{1}, numPulses, amp); %target
+        else
+            [filenames, segmentPoints] = obj.PhaseEstimationSequence(obj.settings.Qubit, direction, numPulses, amp);
+        end
         obj.loadSequence(filenames, 1);
         [data, vardata] = obj.take_data(segmentPoints);
     else

--- a/common/@PulseCalibration/optimize_amplitude.m
+++ b/common/@PulseCalibration/optimize_amplitude.m
@@ -1,15 +1,20 @@
-function amp = optimize_amplitude(obj, amp, direction, target)
+function amp = optimize_amplitude(obj, amp, direction, target, varargin)
     % inputs:
     %   amp - initial guess for pulse amplitude
     %   direction - 'X' or 'Y'
     %   target - target angle (e.g. pi/2 or pi)
     %
     % Attempts to optimize the pulse amplitude for a pi/2 or pi pulse about X or Y.
+    % Optional input: name of target qubit, for CR calibration
 
     done = false;
     ct = 1;
     while ~done
-        [phase, sigma] = obj.measure_rotation_angle(amp, direction, target);
+        if ~isempty(varargin)
+            [phase, sigma] = obj.measure_rotation_angle(amp, direction, target, varargin{1});
+        else
+            [phase, sigma] = obj.measure_rotation_angle(amp, direction, target);
+        end
         ampTarget = target/phase * amp;
         ampError = amp - ampTarget;
         fprintf('Amplitude error: %.4f\n', ampError);

--- a/experiments/muWaveDetection/calibrateCRPulses.m
+++ b/experiments/muWaveDetection/calibrateCRPulses.m
@@ -1,0 +1,58 @@
+function calibrateCRPulses(qc, qt, CR, varargin)
+%Use phase estimation to calibrate the amplitude of CR pulses.
+%Replace cal. step 3 in calibrateCR.m
+%TODO: to be integrated with steps 1 and 2 for length and phase calibration
+
+%optional inputs:
+%expSettingsIn - full or partial ExpSettings structure
+
+%currently supports CR cal with a separate function call per gate, 
+%as the measurement channel is different for each target
+
+p = inputParser;
+addParameter(p,'expSettings', {}, @isstruct)
+parse(p, varargin{:});
+expSettingsIn = p.Results.expSettings;
+
+% construct minimal cfg file
+ExpParams = struct();
+ExpParams.Qubit = qc; %control qubit
+ExpParams.measurement = ['M' qt(end) 'Kernel'];
+ExpParams.DoPi2PhaseCal = 1;  
+ExpParams.NumPi2s = 5;
+ExpParams.dataType = 'real'; %'amp', 'phase', 'real', or 'imag';
+ExpParams.CRpulses = {qt, CR}; 
+
+ExpParams.DoMixerCal = 0; %for compatibility with PulseCalibrationDo
+ExpParams.DoRabiAmp = 0;
+ExpParams.DoRamsey = 0;
+ExpParams.DoPi2Cal = 0;
+ExpParams.DoPiCal = 0;
+ExpParams.DoPiPhaseCal = 0;
+ExpParams.DoDRAGCal = 0;
+ExpParams.DoSPAMCal = 0;
+
+
+ExpParams.cfgFile = getpref('qlab', 'CurScripterFile');
+ExpParams.SoftwareDevelopmentMode = 0;
+
+%optional logging of frequency and amplitudes over time
+ExpParams.dolog = true;
+ExpParams.calpath = 'C:\Users\qlab\Documents\data\Cal_Logs';
+
+if ~isempty(expSettingsIn) %updates ExpParams with optional input settings
+    %Remove overlapping fields from default ExpParams
+    ExpParams = rmfield(ExpParams, intersect(fieldnames(ExpParams), fieldnames(varargin{1})));
+    %Obtain all unique names of remaining fields
+    names = [fieldnames(ExpParams); fieldnames(varargin{1})];
+    %// Merge both structs
+    ExpParams = cell2struct([struct2cell(ExpParams); struct2cell(varargin{1})], names, 1);
+end
+
+% create object instance
+pulseCal = PulseCalibration();
+
+pulseCal.Init(ExpParams);
+pulseCal.Do();
+
+end


### PR DESCRIPTION
Attempt to increase accuracy in CR amplitude calibration. The current
method uses a single CR pulse instead.

I originally intended to integrate it into the existing calibratePulses.m, but it would need different settings for single- and two-qubit calibration. 