### PR TITLE
Cal pulse freq instead of source (optional)

### DIFF
--- a/common/util/updateQubitFreq.m
+++ b/common/util/updateQubitFreq.m
@@ -1,0 +1,6 @@
+function status = updateQubitFreq(qubit, frequency)
+	%frequency: SSB in Hz
+    [thisPath, ~] = fileparts(mfilename('fullpath'));
+    scriptName = fullfile(thisPath, 'updateQubitFreq.py');
+	[status, ~] = system(sprintf('python "%s" "%s" %s %.6f', scriptName, getpref('qlab', 'PyQLabDir'), qubit, frequency));
+end

--- a/common/util/updateQubitFreq.py
+++ b/common/util/updateQubitFreq.py
@@ -1,0 +1,17 @@
+import argparse
+import sys, os
+parser = argparse.ArgumentParser()
+parser.add_argument('pyqlabpath', help='path to PyQLab directory')
+parser.add_argument('qubit', help='qubit')
+parser.add_argument('frequency', type=float, help='SSB frequency')
+args = parser.parse_args()
+
+sys.path.append(args.pyqlabpath)
+from QGL.ChannelLibrary import channelLib
+
+if args.qubit not in channelLib.channelDict:
+	sys.exit(1)
+
+channelLib[args.qubit].frequency = args.frequency
+
+channelLib.write_to_file()

--- a/common/util/updateQubitFreq.py
+++ b/common/util/updateQubitFreq.py
@@ -8,10 +8,18 @@ args = parser.parse_args()
 
 sys.path.append(args.pyqlabpath)
 from QGL.ChannelLibrary import channelLib
+from QGL import *
 
 if args.qubit not in channelLib.channelDict:
 	sys.exit(1)
 
 channelLib[args.qubit].frequency = args.frequency
+
+#updates CR channels 
+q = QubitFactory(args.qubit)
+
+for predecessor in channelLib.connectivityG.predecessors(q):
+	edge = ChannelLibrary.channelLib.connectivityG.edge[predecessor][q]['channel']
+	edge.frequency = args.frequency
 
 channelLib.write_to_file()

--- a/experiments/muWaveDetection/calibratePulses.m
+++ b/experiments/muWaveDetection/calibratePulses.m
@@ -29,6 +29,7 @@ ExpParams.DoSPAMCal = 0;
 ExpParams.OffsetNorm = 6;
 ExpParams.offset2amp = 1/1; % divisor should be the max output voltage of the AWG
 ExpParams.dataType = 'real'; %'amp', 'phase', 'real', or 'imag';
+ExpParams.tuneSource = false;
 
 ExpParams.cfgFile = getpref('qlab', 'CurScripterFile');
 ExpParams.SoftwareDevelopmentMode = 0;


### PR DESCRIPTION
Useful for multiplexing a single source on multiple qubits (or CR
pulses)