### PR TITLE
Calibrate pulse amplitude instead of channel

### DIFF
--- a/experiments/muWaveDetection/CRCal.py
+++ b/experiments/muWaveDetection/CRCal.py
@@ -6,6 +6,7 @@ parser.add_argument('control', help='control qubit name')
 parser.add_argument('target', help='target qubit name')
 parser.add_argument('caltype', type=float, help='1 for length, 2 for phase, 3 for amplitude')
 parser.add_argument('length', type=float, help='step for length calibration or fixed length in phase calibration (ns)')
+parser.add_argument('amplitude', type=float, help='starting pulse amplitude')
 args = parser.parse_args()
 
 from QGL import *
@@ -14,8 +15,8 @@ q2 = QubitFactory(args.control)
 q1 = QubitFactory(args.target)
 
 if args.caltype==1:
-	EchoCRLen(q2,q1,args.length*1e-9*np.arange(1,20),riseFall=40e-9,amp=0.8,showPlot=False)
+	EchoCRLen(q2,q1,args.length*1e-9*np.arange(1,20),riseFall=40e-9,amp=args.amplitude,showPlot=False)
 elif args.caltype==2:
-	EchoCRPhase(q2,q1,np.linspace(0,2*np.pi,19),length=args.length*1e-9,amp=0.8,riseFall=40e-9, showPlot=False)
+	EchoCRPhase(q2,q1,np.linspace(0,2*np.pi,19),length=args.length*1e-9,amp=args.amplitude,riseFall=40e-9, showPlot=False)
 else:
-	EchoCRAmp(q2,q1,np.linspace(0.6,1,19),length=args.length*1e-9,riseFall=40e-9,showPlot=False)
+	EchoCRAmp(q2,q1,np.linspace(args.amplitude*0.8,args.amplitude*1.2,19),length=args.length*1e-9,riseFall=40e-9,showPlot=False)

--- a/experiments/muWaveDetection/CRCalSequence.m
+++ b/experiments/muWaveDetection/CRCalSequence.m
@@ -1,7 +1,11 @@
-function [filename, segmentPoints] = CRCalSequence(control, target, caltype, length)
-
+function [filename, segmentPoints] = CRCalSequence(control, target, caltype, length, varargin)
+if ~isempty(varargin)
+    amplitude = varargin{1};
+else
+    amplitude = 0.8;
+end
 [thisPath, ~] = fileparts(mfilename('fullpath'));
 scriptName = fullfile(thisPath, 'CRCal.py');
-[status, result] = system(sprintf('python "%s" "%s" %s %s %d %d', scriptName, getpref('qlab', 'PyQLabDir'), control, target, caltype, length), '-echo');
+[status, result] = system(sprintf('python "%s" "%s" %s %s %f %f %f', scriptName, getpref('qlab', 'PyQLabDir'), control, target, caltype, length, amplitude), '-echo');
 
 end

--- a/experiments/muWaveDetection/calibrateCR.m
+++ b/experiments/muWaveDetection/calibrateCR.m
@@ -8,9 +8,11 @@ function [optlen, optphase, contrast, optamp] = calibrateCR(control, target, CR,
 p = inputParser;
 addParameter(p,'expSettings', json.read(getpref('qlab', 'CurScripterFile')), @isstruct)
 addParameter(p,'calSteps', [1,1,0])
+addParameter(p,'amplitude',0.8)
 parse(p, varargin{:});
 expSettings = p.Results.expSettings;
 calSteps = p.Results.calSteps;
+amplitude = p.Results.amplitude;
 
 optphase = NaN;
 contrast = NaN;
@@ -22,6 +24,7 @@ CalParams.target = target;
 CalParams.CR = CR;
 CalParams.channel = chan; %meas. channel for target qubit
 CalParams.lenstep = lenstep; %step in length calibration (in ns)
+CalParams.amp = amplitude; %starting pulse amplitude
 
 warning('off', 'json:fieldNameConflict');
 chanSettings = json.read(getpref('qlab', 'ChannelParamsFile'));
@@ -64,7 +67,7 @@ expSettings.saveAllSettings = false;
 
 if calSteps(1)
     %create a sequence with desired range of CR pulse lengths
-    CRCalSequence(CalParams.control, CalParams.target, 1, CalParams.lenstep)  
+    CRCalSequence(CalParams.control, CalParams.target, 1, CalParams.lenstep, CalParams.amp)  
 
     %run the sequence
     ExpScripter2('CRcal_len', expSettings, 'EchoCR/EchoCR');
@@ -79,7 +82,7 @@ end
 if calSteps(2)
     %create a sequence with calibrated length and variable phase
 
-    CRCalSequence(CalParams.control, CalParams.target, 2, optlen)
+    CRCalSequence(CalParams.control, CalParams.target, 2, optlen, CalParams.amp)
 
     %run the sequence
     ExpScripter2('CRcal_ph', expSettings, 'EchoCR/EchoCR');
@@ -91,7 +94,7 @@ end
 
 if calSteps(3)
     %create a sequence with desired range of CR pulse amplitudes
-    CRCalSequence(CalParams.control, CalParams.target, 3, optlen)
+    CRCalSequence(CalParams.control, CalParams.target, 3, optlen, CalParams.amp)
 
     %run the sequence
     ExpScripter2('CRcal_amp', expSettings, 'EchoCR/EchoCR');

--- a/experiments/muWaveDetection/sweep_calibrateCR.m
+++ b/experiments/muWaveDetection/sweep_calibrateCR.m
@@ -1,9 +1,18 @@
-function sweep_calibrateCR(control, target, CR, chan, lenstep, ampvec)
+function sweep_calibrateCR(control, target, CR, chan, lenstep, ampvec, calSteps, varargin)
 %calibrate CR wrapper
+%calSteps = [a,b,c] 0/1 a: length, b: phase c: amplitude 
 persistent figHandles
 if isempty(figHandles)
     figHandles = struct();
 end
+
+%optional input: amplitude sweep 0: channel amp., 1: pulse amp.
+if isempty(varargin)
+    sweep_mode = 0;
+else
+    sweep_mode = varargin{1};
+end
+
 warning('off', 'json:fieldNameConflict');
 chanSettings = json.read(getpref('qlab', 'ChannelParamsFile'));
 chanSettings = chanSettings.channelDict;
@@ -16,9 +25,14 @@ contrastvec = nan(length(ampvec),1);
 
 for k = 1:length(ampvec)
     amp  = ampvec(k);
-    expSettings.instruments.(tmpStr{1}).chan_1.amplitude = amp;
-    expSettings.instruments.(tmpStr{1}).chan_2.amplitude = amp;
-    [optlen, ~, contrast] = calibrateCR(control, target, CR, chan, lenstep, expSettings);
+    if sweep_mode == 0
+        expSettings.instruments.(tmpStr{1}).chan_1.amplitude = amp;
+        expSettings.instruments.(tmpStr{1}).chan_2.amplitude = amp;
+        pulseAmp = 0.8;
+    else
+        pulseAmp = amp;
+    end
+    [optlen, ~, contrast] = calibrateCR(control, target, CR, chan, lenstep, 'expSettings', expSettings, 'calSteps', calSteps, 'amplitude', pulseAmp);
     optlenvec(k) = optlen;
     contrastvec(k) = contrast;
     if ~isfield(figHandles, 'CRsweep') || ~ishandle(figHandles.( 'CRsweep'))


### PR DESCRIPTION
Useful when physical channels are shared between multiple logical channels (e.g. control qubit and CR pulses)