### PR TITLE
Feature/cavity reset cal

### DIFF
--- a/analysis/cQED_dataAnalysis/fit_photon_number.m
+++ b/analysis/cQED_dataAnalysis/fit_photon_number.m
@@ -1,0 +1,87 @@
+function [n, nerr] = fit_photon_number(xdata, ydata, params)
+% Fit photon number from a Ramsey following a measurement pulse. 
+% see McClure et al., Phys. Rev. Applied 5, 011001 
+
+persistent figHandles
+if isempty(figHandles)
+    figHandles = struct();
+end
+
+% input params:
+%  1 - cavity decay rate kappa (MHz)
+%  2 - detuning Delta (2*pi*MHz)
+%  3 - dispersive shift 2Chi (2*pi*MHz)
+%  4 - Ramsey decay time T2* (us)
+%  5 - exp(-t_meas/T1), to include relaxation during msm't
+%  6 - initial qubit state (0/1)
+
+if nargin < 2 
+    h = gcf;
+    line = findall(h, 'Type', 'Line');
+    xdata = get(line(1), 'xdata');
+    ydata = get(line(1), 'ydata');
+    % save figure title
+    plotTitle = get(get(gca, 'Title'), 'String');
+    %convert xaxis to ns
+    if ~isempty(strfind(get(get(gca, 'xlabel'), 'String'), '\mus')) || ~isempty(strfind(get(get(gca, 'xlabel'), 'String'), 'us'))
+        xdata = xdata*1e3;
+    elseif ~isempty(strfind(get(get(gca, 'xlabel'), 'String'), 'ms'))
+        xdata = xdata*1e6;
+    elseif ~isempty(strfind(get(get(gca, 'xlabel'), 'String'), 's'))
+        xdata = xdata*1e9;
+    end
+else
+    if ~isfield(figHandles, 'Ramsey') || ~ishandle(figHandles.('Ramsey'))
+        figHandles.('Ramsey') = figure('Name', 'Ramsey');
+        h = figHandles.('Ramsey');
+    else
+        h = figure(figHandles.('Ramsey')); clf;
+    end
+    plotTitle = 'Fit to qubit frequency with variable photon number';
+end
+
+y = ydata(:);
+drawnow()
+
+% if xdata is a single value, assume that it is the time step
+if length(xdata) == 1
+    xdata = 0:xdata:xdata*(length(y)-1);
+end
+% construct finer step tdata for plotting fit
+xdata_finer = linspace(0, max(xdata), 4*length(xdata));
+
+xdata = xdata(:);
+xdata_finer = xdata_finer(:);
+
+model = @(p, tdata)((-imag(exp(-(1/params(4)+params(2)*1j).*tdata + (p(1)-1*p(2)*params(3)*(1-exp(-((params(1) + params(3)*1j).*tdata)))/(params(1)+params(3)*1j))*1j)))*(1+(params(5)-1)*params(6))...
+     +params(6)*(-imag(exp(-(1/params(4)+params(2)*1j).*tdata + (p(1)+pi-1*p(2)*params(3)*(1-exp(-((params(1) + params(3)*1j).*tdata)))/(params(1)+params(3)*1j))*1j)))*(1-params(5)));
+
+p = [0 0.5];
+[beta,r,j] = nlinfit(xdata, y, model, p);
+ci = nlparci(beta,r,j);
+n = beta(2); %photon number
+nerr = (ci(2,2)-ci(2,1))/2;
+
+figure(h)
+subplot(3,1,2:3)
+plot(xdata/1e3,y,'o')
+hold on
+plot(xdata_finer/1e3,model(beta,xdata_finer),'-r')
+xlabel('Time [\mus]')
+ylabel('<\sigma_z>')
+hold off
+subplot(3,1,1)
+bar(xdata/1e3,r)
+axis tight
+xlabel('Time [\mus]')
+ylabel('Residuals [V]')
+title(plotTitle)
+
+subplot(3,1,2:3)
+ylim([-1.05 1.05])
+
+ text(xdata(end-1)/1e3, 0.8, ...
+     sprintf('n_0 = %.2f +/- %.2f \n', n, nerr), ...
+     'HorizontalAlignment', 'right', 'VerticalAlignment', 'top');
+
+

--- a/experiments/muWaveDetection/CLEARCal.py
+++ b/experiments/muWaveDetection/CLEARCal.py
@@ -1,0 +1,37 @@
+import argparse
+import sys, os
+parser = argparse.ArgumentParser()
+parser.add_argument('qubit', help='qubit name')
+parser.add_argument('meas_qubit', help='name of auxiliary qubit for msm''t pulse')
+parser.add_argument('ramsey_stop', type=float, help='max pulse spacing (in us)')
+parser.add_argument('npoints', type=int, help='number of segments')
+parser.add_argument('ramsey_freq', type=float, help='virtual Ramsey frequency (in MHz)')
+parser.add_argument('delay', type=float, help='delay between end of Ramsey and final msm''t (in us)')
+parser.add_argument('eps1', type=float, help='amplitude of first CLEAR step')
+parser.add_argument('eps2', type=float, help='amplitude of second CLEAR step')
+parser.add_argument('tau', type=float, help='length of each CLEAR step (us)')
+parser.add_argument('state', type=int, help='initial qubit state (0/1)')
+
+
+args = parser.parse_args()
+
+from QGL import *
+
+q = QubitFactory(args.qubit)
+qM = QubitFactory(args.meas_qubit)
+
+pulseSpacings = np.linspace(0, args.ramsey_stop*1e-6, args.npoints)
+
+Prep = X(q) if args.state else Id(q)
+
+#print MEAS(qM).amp
+#amp_end = abs(MEAS(qM).shape[int(-2e9*args.tau)]) #pulse amplitude at the end of the pulse, before CLEAR steps. Used to normalize eps1, eps2
+#print amp_end
+#print args.eps1
+
+seqs = [[Prep, MEAS(qM, amp1 = args.eps1, amp2 = args.eps2, step_length = args.tau*1e-6), X90(q), Id(q,d), U90(q,phase = args.ramsey_freq*1e6*d), Id(q, args.delay*1e-6), MEAS(q)] for d in pulseSpacings]
+seqs += create_cal_seqs((q,), 2, delay = args.delay*1e-6)
+
+fileNames = compile_to_hardware(seqs, fileName='CLEARCal/CLEARCal',axis_descriptor=[
+            time_descriptor(pulseSpacings),
+            cal_descriptor((q,), 2)])

--- a/experiments/muWaveDetection/CLEARCalSequence.m
+++ b/experiments/muWaveDetection/CLEARCalSequence.m
@@ -1,0 +1,6 @@
+function CLEARCalSequence(qubit, meas_qubit, ramsey_stop, npoints, ramsey_freq, delay, eps1, eps2, tau, state)
+
+[thisPath, ~] = fileparts(mfilename('fullpath'));
+scriptName = fullfile(thisPath, 'CLEARCal.py');
+system(sprintf('python "%s" "%s" "%s" %f %d %f %.3f %f %f %.3f %d', scriptName, qubit, meas_qubit, ramsey_stop, npoints, ramsey_freq, delay, eps1, eps2, tau, state), '-echo');
+end

--- a/experiments/muWaveDetection/calibrate_CLEAR.m
+++ b/experiments/muWaveDetection/calibrate_CLEAR.m
@@ -90,8 +90,10 @@ for ct = 1:3
         data = load_data('latest');
         caldata = real(cal_scale(data.data));
         n1vec(k) = fit_photon_number(xpoints, caldata, [kappa, ramsey_freq, 2*chi, T2, T1factor, 1]);
-        figure(figHandles.('CLEAR'));
+        figure(figHandles.('CLEAR')); 
+        set(gcf,'position',[550,300,1000,350])
         subplot(1,3,ct)
+        hold off
         plot(xpts(1:k), n0vec(1:k), '.-','markerSize', 10, 'Color', ColOrd(1,:));
         hold on;
         plot(xpts(1:k), n1vec(1:k), '.-','markerSize', 10, 'Color', ColOrd(2,:));
@@ -119,11 +121,11 @@ for ct = 1:3
     [~, fit_x0] = min(quadf(beta0, xfine));
     figure(figHandles.('CLEAR'));
     hold on;
-    plot(xfine, quadf(beta0, xfine), 'Color', ColOrd(1,:));
+    plot(xfine, quadf(beta0, xfine), '--', 'Color', ColOrd(1,:));
     [beta1,~,~] = nlinfit(xpts', n1vec, quadf, p1);
     [~, fit_x1] = min(quadf(beta1, xfine));
     hold on;
-    plot(xfine, quadf(beta1, xfine), 'Color', ColOrd(2,:));
+    plot(xfine, quadf(beta1, xfine), '--', 'Color', ColOrd(2,:));
     legend('0', '1', 'fit, 0', 'fit, 1')
     ylim([-0.2,3])
     opt_scaling = (xfine(fit_x0)+xfine(fit_x1))/2;
@@ -132,7 +134,10 @@ for ct = 1:3
     %update best eps1, eps2
     eps1_0 = eps1_0*opt_scaling;
     eps2_0 = eps2_0*opt_scaling;
-    fprintf('Updated \epsilon_1 =  %.3f, \epsilon_2 = %.3f\n', eps1_0, eps2_0);
+    str1 = '$$ \epsilon_1 $$';
+    str2 = '$$ \epsilon_2 $$';
+    %eps1_s = num2str(eps1_0)
+    text(0, 0.2, [str1 ' = ' num2str(eps1_0,3) '; ' str2 ' = ' num2str(eps2_0,3)],'HorizontalAlignment', 'left', 'VerticalAlignment', 'top','Interpreter','latex');
 end
 %TODO: update pulse shape. Make these parameters?
 end

--- a/experiments/muWaveDetection/calibrate_CLEAR.m
+++ b/experiments/muWaveDetection/calibrate_CLEAR.m
@@ -59,7 +59,7 @@ ColOrd = get(gca,'ColorOrder');
 %Sweep amplitude of CLEAR steps, keeping the ration eps2/eps1 constant
 for ct = 1:3
     if ~calsteps(ct)
-        break
+        continue
     end
     fprintf('Calibration step %d\n', ct);
     xpts = linspace(1-calsteps(ct), 1+calsteps(ct), nsteps);
@@ -132,12 +132,20 @@ for ct = 1:3
     fprintf('Optimum scaling factor: %.2f\n', opt_scaling);
     
     %update best eps1, eps2
-    eps1_0 = eps1_0*opt_scaling;
-    eps2_0 = eps2_0*opt_scaling;
+    switch ct
+        case 1
+            eps1_0 = eps1_0*opt_scaling;
+            eps2_0 = eps2_0*opt_scaling;
+        case 2
+            eps1_0 = eps1_0*opt_scaling;
+        case 3
+            eps2_0 = eps2_0*opt_scaling;
+    end
+    
     str1 = '$$ \epsilon_1 $$';
     str2 = '$$ \epsilon_2 $$';
     %eps1_s = num2str(eps1_0)
-    text(0, 0.2, [str1 ' = ' num2str(eps1_0,3) '; ' str2 ' = ' num2str(eps2_0,3)],'HorizontalAlignment', 'left', 'VerticalAlignment', 'top','Interpreter','latex');
+    text(0.2, 0.2, [str1 ' = ' num2str(eps1_0,3) '; ' str2 ' = ' num2str(eps2_0,3)],'HorizontalAlignment', 'left', 'VerticalAlignment', 'top','Interpreter','latex');
 end
 %TODO: update pulse shape. Make these parameters?
 end

--- a/experiments/muWaveDetection/calibrate_CLEAR.m
+++ b/experiments/muWaveDetection/calibrate_CLEAR.m
@@ -1,0 +1,140 @@
+function [eps1_0, eps2_0] = calibrate_CLEAR(qubit, meas_qubit, kappa, chi, t_empty, varargin)
+%search for the optimum 2-step CLEAR pulse, starting from an initial guess
+
+persistent figHandles
+if isempty(figHandles)
+    figHandles = struct();
+end
+
+%Arguments:
+%qubit
+%meas_qubit: auxiliary qubit used for CLEAR pulse
+%kappa: cavity linewidth (1/us)
+%chi: half of the dispershive shift (1/us)
+%t_empty: time allowed to deplete the cavity (us)
+%note: kappa, chi are angular frequencies (1/time)
+
+parser = inputParser;
+
+addOptional(parser, 'ramsey_stop', 2, @isnumeric);
+addOptional(parser, 'npoints', 101, @isnumeric);
+addOptional(parser, 'ramsey_freq', 2*pi*4, @isnumeric);
+addOptional(parser, 'delay', 1.5, @isnumeric);
+addOptional(parser, 'alpha', 0.4, @isnumeric); %rescaling factor
+addOptional(parser, 'T1factor', exp(-1/30), @isnumeric); %T1 decay before Ramsey
+addOptional(parser, 'T2', 30, @isnumeric); %T2*
+addOptional(parser, 'nsteps', 11, @isnumeric); %calibration steps (/ sweep)
+addOptional(parser, 'calsteps', [1 1 1]); %choose ranges for calibration steps: 1: +-100%; 0: skip step
+
+%Start from theoretical values, unless given as inputs
+eps1_th = (1 - 2*exp(kappa*t_empty/4)*cos(chi*t_empty/2))/(1+exp(kappa*t_empty/2)-2*exp(kappa*t_empty/4)*cos(chi*t_empty/2));
+eps2_th = 1/(1+exp(kappa*t_empty/2)-2*exp(kappa*t_empty/4)*cos(chi*t_empty/2));
+
+addOptional(parser, 'eps1', eps1_th, @isnumeric);
+addOptional(parser, 'eps2', eps2_th, @isnumeric);
+parse(parser, varargin{:});
+ramsey_stop = parser.Results.ramsey_stop;
+npoints = parser.Results.npoints;
+ramsey_freq = parser.Results.ramsey_freq;
+delay = parser.Results.delay;
+alpha = parser.Results.alpha;
+T1factor = parser.Results.T1factor;
+T2 = parser.Results.T2;
+nsteps = parser.Results.nsteps;
+calsteps = parser.Results.calsteps;
+eps1_0 = parser.Results.eps1;
+eps2_0 = parser.Results.eps2;
+
+xpoints = linspace(0, ramsey_stop, npoints);
+n0vec = zeros(nsteps,1);
+n1vec = zeros(nsteps,1);
+
+if ~isfield(figHandles, 'CLEAR') || ~ishandle(figHandles.('CLEAR'))
+    figHandles.('CLEAR') = figure('Name', 'CLEAR','Visible','Off');
+else
+    figure(figHandles.('CLEAR'),'Visible','Off'); clf()
+end
+ColOrd = get(gca,'ColorOrder');
+
+%Sweep amplitude of CLEAR steps, keeping the ration eps2/eps1 constant
+for ct = 1:3
+    if ~calsteps(ct)
+        break
+    end
+    fprintf('Calibration step %d\n', ct);
+    xpts = linspace(1-calsteps(ct), 1+calsteps(ct), nsteps);
+    for k=1:nsteps
+        switch ct
+            case 1
+                eps1 = xpts(k)*eps1_0;
+                eps2 = xpts(k)*eps2_0;
+            case 2
+                eps1 = xpts(k)*eps1_0;
+                eps2 = eps2_0;
+            case 3
+                eps1 = eps1_0;
+                eps2 = xpts(k)*eps2_0;
+        end
+        %Generate the sequence
+        CLEARCalSequence(qubit, meas_qubit, ramsey_stop, npoints, ramsey_freq, delay, eps1*alpha, eps2*alpha, t_empty/2, 0)
+        %Run the sequence
+        ExpScripter2('CLEAR_cal', 'CLEARCal\CLEARCal', 'lockSegments') %temporary kludge to deal with multiple measurements on different logical channels
+        %Fit photon number
+        data = load_data('latest');
+        caldata = real(cal_scale(data.data));
+        n0vec(k) = fit_photon_number(xpoints, caldata, [kappa, ramsey_freq, 2*chi, T2, T1factor, 0]);
+        
+        %Repeat for qubit in |1>
+        CLEARCalSequence(qubit, meas_qubit, ramsey_stop, npoints, ramsey_freq, delay, eps1*alpha, eps2*alpha, t_empty/2, 0)
+        ExpScripter2('CLEAR_cal', 'CLEARCal\CLEARCal', 'lockSegments')
+        data = load_data('latest');
+        caldata = real(cal_scale(data.data));
+        n1vec(k) = fit_photon_number(xpoints, caldata, [kappa, ramsey_freq, 2*chi, T2, T1factor, 1]);
+        figure(figHandles.('CLEAR'));
+        subplot(1,3,ct)
+        plot(xpts(1:k), n0vec(1:k), '.-','markerSize', 10, 'Color', ColOrd(1,:));
+        hold on;
+        plot(xpts(1:k), n1vec(1:k), '.-','markerSize', 10, 'Color', ColOrd(2,:));
+        title(sprintf('CLEAR calibration, step %d', ct))
+        switch ct
+            case 1
+                sweep_label = '\epsilon_1, \epsilon_2';
+            case 2
+                sweep_label = '\epsilon_1';
+            case 3
+                sweep_label = '\epsilon_2';
+        end
+        xlabel(['Scaling factor ' sweep_label])
+        ylabel('Photon number n_0')
+        drawnow()
+    end
+    %Fit for minimum photon number
+    [~,x0] = min(n0vec);
+    [~,x1] = min(n1vec);
+    quadf = inline('p(1)*(tdata - p(2)).^2 + p(3)','p','tdata');
+    xfine = linspace(0,2,1001);
+    p0 = [1 x0 0];
+    p1 = [1 x1 0];
+    [beta0,~,~] = nlinfit(xpts', n0vec, quadf, p0);
+    [~, fit_x0] = min(quadf(beta0, xfine));
+    figure(figHandles.('CLEAR'));
+    hold on;
+    plot(xfine, quadf(beta0, xfine), 'Color', ColOrd(1,:));
+    [beta1,~,~] = nlinfit(xpts', n1vec, quadf, p1);
+    [~, fit_x1] = min(quadf(beta1, xfine));
+    hold on;
+    plot(xfine, quadf(beta1, xfine), 'Color', ColOrd(2,:));
+    legend('0', '1', 'fit, 0', 'fit, 1')
+    ylim([-0.2,3])
+    opt_scaling = (xfine(fit_x0)+xfine(fit_x1))/2;
+    fprintf('Optimum scaling factor: %.2f\n', opt_scaling);
+    
+    %update best eps1, eps2
+    eps1_0 = eps1_0*opt_scaling;
+    eps2_0 = eps2_0*opt_scaling;
+    fprintf('Updated \epsilon_1 =  %.3f, \epsilon_2 = %.3f\n', eps1_0, eps2_0);
+end
+%TODO: update pulse shape. Make these parameters?
+end
+
+


### PR DESCRIPTION
calibration routine for 2-step CLEAR pulse (McClure et al., 2016)

Protocol:
- measure photon population after measurement using a Ramsey seq. (see above)
- apply ideal CLEAR pulse (from theory)
- sweep step amplitudes around the ideal values

Using:
- CLEAR pulse shape (= measPulse followed by 2 steps)

TODO:
- update pulse shape at the end of calibration (make the step amplitudes pulse parameters?)
- metafile info supporting multiple msm't on same physical channel, but different logical channels