### PR TITLE
Update set of pulses defined by the pulse library

### DIFF
--- a/common/util/update_wf_lib.py
+++ b/common/util/update_wf_lib.py
@@ -10,13 +10,17 @@ args = parser.parse_args()
 
 from QGL import *
 from QGL.drivers import APS2Pattern
+from QGL import config
 
 qubits = ChannelLibrary.channelLib.connectivityG.nodes()
 edges = ChannelLibrary.channelLib.connectivityG.edges()
 
 pulseList = []
 for q in qubits:
-	pulseList.append([AC(q, ct) for ct in range(24)])
+	if config.pulse_primitives_lib == 'standard':
+		pulseList.append([AC(q, ct) for ct in range(24)])
+	else:
+		pulseList.append([X90(q), Y90(q), X90m(q), Y90m(q)])
 for edge in edges:
 	pulseList.append(ZX90_CR(edge[0],edge[1]))
 #update waveforms in the desired sequence (generated with APS2Pattern.SAVE_WF_OFFSETS = True)


### PR DESCRIPTION
The amplitude of a composite pulse is not defined. If we use the `'all90'` library we just want to update `X90`s and `Y90`s